### PR TITLE
fix: changed names in yaml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@
 # Feel free to take a look at our documentation (https://docs.sonarcloud.io/getting-started/github/)
 # or reach out to our community forum if you need some help (https://community.sonarsource.com/c/help/sc/9)
 
-name: SonarCloud analysis
+name: Code Analysis
 
 on:
   push:
@@ -55,8 +55,8 @@ jobs:
           args:
             # Unique keys of your project and organization. You can find them in SonarCloud > Information (bottom-left menu)
             # mandatory
-            -Dsonar.projectKey=
-            -Dsonar.organization=
+            -Dsonar.projectKey=MCarlquist_Sunrise
+            -Dsonar.organization=mcarlquist
             # Comma-separated paths to directories containing main source files.
             #-Dsonar.sources= # optional, default is project base directory
             # Comma-separated paths to directories containing test source files.


### PR DESCRIPTION
## Summary by Sourcery

Update the SonarCloud GitHub Actions workflow name and configure it with the actual project key and organization values

CI:
- Rename the workflow from 'SonarCloud analysis' to 'Code Analysis'
- Set sonar.projectKey to 'MCarlquist_Sunrise' and sonar.organization to 'mcarlquist' in the workflow