### PR TITLE
Update onboarding and mood API responses and docs

### DIFF
--- a/backend/routes/api/mood.test.ts
+++ b/backend/routes/api/mood.test.ts
@@ -1,0 +1,846 @@
+import request from 'supertest';
+import { app } from '../../../app';
+import { MoodService } from '../../../services/MoodService';
+import { AuthService } from '../../../services/AuthService';
+import { ValidationError, NotFoundError, UnauthorizedError } from '../../../utils/errors';
+import { MoodEntry, MoodType } from '../../../types/mood';
+
+// Mock external dependencies
+jest.mock('../../../services/MoodService');
+jest.mock('../../../services/AuthService');
+
+const mockMoodService = MoodService as jest.Mocked<typeof MoodService>;
+const mockAuthService = AuthService as jest.Mocked<typeof AuthService>;
+
+describe('Mood API Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/mood', () => {
+    const mockUserId = 'user123';
+    const mockMoodEntries: MoodEntry[] = [
+      {
+        id: '1',
+        userId: mockUserId,
+        mood: MoodType.HAPPY,
+        note: 'Great day!',
+        createdAt: new Date('2023-01-01T10:00:00Z'),
+        updatedAt: new Date('2023-01-01T10:00:00Z')
+      },
+      {
+        id: '2',
+        userId: mockUserId,
+        mood: MoodType.SAD,
+        note: 'Not feeling well',
+        createdAt: new Date('2023-01-02T10:00:00Z'),
+        updatedAt: new Date('2023-01-02T10:00:00Z')
+      }
+    ];
+
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: mockUserId });
+    });
+
+    it('should return mood entries for authenticated user', async () => {
+      mockMoodService.getMoodEntries.mockResolvedValue(mockMoodEntries);
+
+      const response = await request(app)
+        .get('/api/mood')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        data: mockMoodEntries
+      });
+      expect(mockMoodService.getMoodEntries).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should return filtered mood entries by date range', async () => {
+      const filteredEntries = [mockMoodEntries[0]];
+      mockMoodService.getMoodEntries.mockResolvedValue(filteredEntries);
+
+      const response = await request(app)
+        .get('/api/mood')
+        .query({
+          startDate: '2023-01-01',
+          endDate: '2023-01-01'
+        })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(filteredEntries);
+      expect(mockMoodService.getMoodEntries).toHaveBeenCalledWith(
+        mockUserId,
+        new Date('2023-01-01'),
+        new Date('2023-01-01')
+      );
+    });
+
+    it('should return filtered mood entries by mood type', async () => {
+      const filteredEntries = [mockMoodEntries[0]];
+      mockMoodService.getMoodEntries.mockResolvedValue(filteredEntries);
+
+      const response = await request(app)
+        .get('/api/mood')
+        .query({ moodType: MoodType.HAPPY })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(filteredEntries);
+      expect(mockMoodService.getMoodEntries).toHaveBeenCalledWith(
+        mockUserId,
+        undefined,
+        undefined,
+        MoodType.HAPPY
+      );
+    });
+
+    it('should return 401 when no authorization header is provided', async () => {
+      const response = await request(app).get('/api/mood');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authorization header required'
+      });
+    });
+
+    it('should return 401 when token is invalid', async () => {
+      mockAuthService.validateToken.mockRejectedValue(new UnauthorizedError('Invalid token'));
+
+      const response = await request(app)
+        .get('/api/mood')
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid token'
+      });
+    });
+
+    it('should return 400 when date range is invalid', async () => {
+      const response = await request(app)
+        .get('/api/mood')
+        .query({
+          startDate: 'invalid-date',
+          endDate: '2023-01-01'
+        })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid date format'
+      });
+    });
+
+    it('should return 500 when service throws unexpected error', async () => {
+      mockMoodService.getMoodEntries.mockRejectedValue(new Error('Database connection failed'));
+
+      const response = await request(app)
+        .get('/api/mood')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error'
+      });
+    });
+
+    it('should return empty array when user has no mood entries', async () => {
+      mockMoodService.getMoodEntries.mockResolvedValue([]);
+
+      const response = await request(app)
+        .get('/api/mood')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        data: []
+      });
+    });
+
+    it('should handle pagination parameters', async () => {
+      mockMoodService.getMoodEntries.mockResolvedValue(mockMoodEntries);
+
+      const response = await request(app)
+        .get('/api/mood')
+        .query({ page: '1', limit: '10' })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(mockMoodService.getMoodEntries).toHaveBeenCalledWith(
+        mockUserId,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        10
+      );
+    });
+
+    it('should validate pagination parameters', async () => {
+      const response = await request(app)
+        .get('/api/mood')
+        .query({ page: '-1', limit: '0' })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid pagination parameters'
+      });
+    });
+  });
+
+  describe('POST /api/mood', () => {
+    const mockUserId = 'user123';
+    const validMoodData = {
+      mood: MoodType.HAPPY,
+      note: 'Feeling great today!'
+    };
+
+    const mockCreatedEntry: MoodEntry = {
+      id: 'mood123',
+      userId: mockUserId,
+      mood: MoodType.HAPPY,
+      note: 'Feeling great today!',
+      createdAt: new Date('2023-01-01T10:00:00Z'),
+      updatedAt: new Date('2023-01-01T10:00:00Z')
+    };
+
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: mockUserId });
+    });
+
+    it('should create a new mood entry successfully', async () => {
+      mockMoodService.createMoodEntry.mockResolvedValue(mockCreatedEntry);
+
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validMoodData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual({
+        success: true,
+        data: mockCreatedEntry
+      });
+      expect(mockMoodService.createMoodEntry).toHaveBeenCalledWith(
+        mockUserId,
+        validMoodData.mood,
+        validMoodData.note
+      );
+    });
+
+    it('should create mood entry without note', async () => {
+      const dataWithoutNote = { mood: MoodType.NEUTRAL };
+      const entryWithoutNote = { ...mockCreatedEntry, note: undefined };
+      mockMoodService.createMoodEntry.mockResolvedValue(entryWithoutNote);
+
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send(dataWithoutNote);
+
+      expect(response.status).toBe(201);
+      expect(mockMoodService.createMoodEntry).toHaveBeenCalledWith(
+        mockUserId,
+        MoodType.NEUTRAL,
+        undefined
+      );
+    });
+
+    it('should return 400 when mood type is missing', async () => {
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ note: 'Just a note' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Mood type is required'
+      });
+    });
+
+    it('should return 400 when mood type is invalid', async () => {
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ mood: 'INVALID_MOOD', note: 'Test note' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid mood type'
+      });
+    });
+
+    it('should return 400 when note is too long', async () => {
+      const longNote = 'a'.repeat(1001); // Assuming 1000 char limit
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ mood: MoodType.HAPPY, note: longNote });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Note cannot exceed 1000 characters'
+      });
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      const response = await request(app)
+        .post('/api/mood')
+        .send(validMoodData);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authorization header required'
+      });
+    });
+
+    it('should return 401 when token is invalid', async () => {
+      mockAuthService.validateToken.mockRejectedValue(new UnauthorizedError('Invalid token'));
+
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validMoodData);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid token'
+      });
+    });
+
+    it('should return 400 when request body is empty', async () => {
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Mood type is required'
+      });
+    });
+
+    it('should return 500 when service throws unexpected error', async () => {
+      mockMoodService.createMoodEntry.mockRejectedValue(new Error('Database error'));
+
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validMoodData);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error'
+      });
+    });
+
+    it('should sanitize HTML in note field', async () => {
+      const maliciousNote = '<script>alert("xss")</script>Safe note';
+      const sanitizedEntry = { ...mockCreatedEntry, note: 'Safe note' };
+      mockMoodService.createMoodEntry.mockResolvedValue(sanitizedEntry);
+
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ mood: MoodType.HAPPY, note: maliciousNote });
+
+      expect(response.status).toBe(201);
+      expect(mockMoodService.createMoodEntry).toHaveBeenCalledWith(
+        mockUserId,
+        MoodType.HAPPY,
+        'Safe note'
+      );
+    });
+
+    it('should trim whitespace from note field', async () => {
+      const noteWithWhitespace = '   Feeling good   ';
+      const trimmedEntry = { ...mockCreatedEntry, note: 'Feeling good' };
+      mockMoodService.createMoodEntry.mockResolvedValue(trimmedEntry);
+
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ mood: MoodType.HAPPY, note: noteWithWhitespace });
+
+      expect(response.status).toBe(201);
+      expect(mockMoodService.createMoodEntry).toHaveBeenCalledWith(
+        mockUserId,
+        MoodType.HAPPY,
+        'Feeling good'
+      );
+    });
+  });
+
+  describe('GET /api/mood/:id', () => {
+    const mockUserId = 'user123';
+    const mockMoodId = 'mood123';
+    const mockMoodEntry: MoodEntry = {
+      id: mockMoodId,
+      userId: mockUserId,
+      mood: MoodType.HAPPY,
+      note: 'Great day!',
+      createdAt: new Date('2023-01-01T10:00:00Z'),
+      updatedAt: new Date('2023-01-01T10:00:00Z')
+    };
+
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: mockUserId });
+    });
+
+    it('should return mood entry by id', async () => {
+      mockMoodService.getMoodEntryById.mockResolvedValue(mockMoodEntry);
+
+      const response = await request(app)
+        .get(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        data: mockMoodEntry
+      });
+      expect(mockMoodService.getMoodEntryById).toHaveBeenCalledWith(mockMoodId, mockUserId);
+    });
+
+    it('should return 404 when mood entry not found', async () => {
+      mockMoodService.getMoodEntryById.mockRejectedValue(new NotFoundError('Mood entry not found'));
+
+      const response = await request(app)
+        .get(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Mood entry not found'
+      });
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      const response = await request(app).get(`/api/mood/${mockMoodId}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authorization header required'
+      });
+    });
+
+    it('should return 400 when id format is invalid', async () => {
+      const response = await request(app)
+        .get('/api/mood/invalid-id-format')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid mood entry ID format'
+      });
+    });
+
+    it('should return 403 when user tries to access another users mood entry', async () => {
+      mockMoodService.getMoodEntryById.mockRejectedValue(new UnauthorizedError('Access denied'));
+
+      const response = await request(app)
+        .get(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Access denied'
+      });
+    });
+  });
+
+  describe('PUT /api/mood/:id', () => {
+    const mockUserId = 'user123';
+    const mockMoodId = 'mood123';
+    const updateData = {
+      mood: MoodType.NEUTRAL,
+      note: 'Updated note'
+    };
+
+    const mockUpdatedEntry: MoodEntry = {
+      id: mockMoodId,
+      userId: mockUserId,
+      mood: MoodType.NEUTRAL,
+      note: 'Updated note',
+      createdAt: new Date('2023-01-01T10:00:00Z'),
+      updatedAt: new Date('2023-01-01T12:00:00Z')
+    };
+
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: mockUserId });
+    });
+
+    it('should update mood entry successfully', async () => {
+      mockMoodService.updateMoodEntry.mockResolvedValue(mockUpdatedEntry);
+
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token')
+        .send(updateData);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        data: mockUpdatedEntry
+      });
+      expect(mockMoodService.updateMoodEntry).toHaveBeenCalledWith(
+        mockMoodId,
+        mockUserId,
+        updateData
+      );
+    });
+
+    it('should update only mood without note', async () => {
+      const moodOnlyUpdate = { mood: MoodType.SAD };
+      const updatedEntry = { ...mockUpdatedEntry, mood: MoodType.SAD };
+      mockMoodService.updateMoodEntry.mockResolvedValue(updatedEntry);
+
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token')
+        .send(moodOnlyUpdate);
+
+      expect(response.status).toBe(200);
+      expect(mockMoodService.updateMoodEntry).toHaveBeenCalledWith(
+        mockMoodId,
+        mockUserId,
+        moodOnlyUpdate
+      );
+    });
+
+    it('should return 404 when mood entry not found', async () => {
+      mockMoodService.updateMoodEntry.mockRejectedValue(new NotFoundError('Mood entry not found'));
+
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token')
+        .send(updateData);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Mood entry not found'
+      });
+    });
+
+    it('should return 400 when update data is invalid', async () => {
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token')
+        .send({ mood: 'INVALID_MOOD' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid mood type'
+      });
+    });
+
+    it('should return 400 when no update data provided', async () => {
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token')
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'At least one field must be provided for update'
+      });
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .send(updateData);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authorization header required'
+      });
+    });
+
+    it('should return 403 when user tries to update another users mood entry', async () => {
+      mockMoodService.updateMoodEntry.mockRejectedValue(new UnauthorizedError('Access denied'));
+
+      const response = await request(app)
+        .put(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token')
+        .send(updateData);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Access denied'
+      });
+    });
+  });
+
+  describe('DELETE /api/mood/:id', () => {
+    const mockUserId = 'user123';
+    const mockMoodId = 'mood123';
+
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: mockUserId });
+    });
+
+    it('should delete mood entry successfully', async () => {
+      mockMoodService.deleteMoodEntry.mockResolvedValue(true);
+
+      const response = await request(app)
+        .delete(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        message: 'Mood entry deleted successfully'
+      });
+      expect(mockMoodService.deleteMoodEntry).toHaveBeenCalledWith(mockMoodId, mockUserId);
+    });
+
+    it('should return 404 when mood entry not found', async () => {
+      mockMoodService.deleteMoodEntry.mockRejectedValue(new NotFoundError('Mood entry not found'));
+
+      const response = await request(app)
+        .delete(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Mood entry not found'
+      });
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      const response = await request(app).delete(`/api/mood/${mockMoodId}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authorization header required'
+      });
+    });
+
+    it('should return 403 when user tries to delete another users mood entry', async () => {
+      mockMoodService.deleteMoodEntry.mockRejectedValue(new UnauthorizedError('Access denied'));
+
+      const response = await request(app)
+        .delete(`/api/mood/${mockMoodId}`)
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Access denied'
+      });
+    });
+
+    it('should return 400 when id format is invalid', async () => {
+      const response = await request(app)
+        .delete('/api/mood/invalid-id-format')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid mood entry ID format'
+      });
+    });
+  });
+
+  describe('GET /api/mood/analytics', () => {
+    const mockUserId = 'user123';
+    const mockAnalytics = {
+      totalEntries: 10,
+      moodDistribution: {
+        [MoodType.HAPPY]: 4,
+        [MoodType.SAD]: 2,
+        [MoodType.NEUTRAL]: 3,
+        [MoodType.ANGRY]: 1
+      },
+      averageMoodScore: 3.2,
+      streaks: {
+        current: 5,
+        longest: 12
+      }
+    };
+
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: mockUserId });
+    });
+
+    it('should return mood analytics', async () => {
+      mockMoodService.getMoodAnalytics.mockResolvedValue(mockAnalytics);
+
+      const response = await request(app)
+        .get('/api/mood/analytics')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        data: mockAnalytics
+      });
+      expect(mockMoodService.getMoodAnalytics).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should return analytics with date range filter', async () => {
+      mockMoodService.getMoodAnalytics.mockResolvedValue(mockAnalytics);
+
+      const response = await request(app)
+        .get('/api/mood/analytics')
+        .query({
+          startDate: '2023-01-01',
+          endDate: '2023-01-31'
+        })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(200);
+      expect(mockMoodService.getMoodAnalytics).toHaveBeenCalledWith(
+        mockUserId,
+        new Date('2023-01-01'),
+        new Date('2023-01-31')
+      );
+    });
+
+    it('should return 401 when user is not authenticated', async () => {
+      const response = await request(app).get('/api/mood/analytics');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authorization header required'
+      });
+    });
+
+    it('should return 400 when date range is invalid', async () => {
+      const response = await request(app)
+        .get('/api/mood/analytics')
+        .query({
+          startDate: 'invalid-date',
+          endDate: '2023-01-31'
+        })
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid date format'
+      });
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    beforeEach(() => {
+      mockAuthService.validateToken.mockResolvedValue({ userId: 'user123' });
+    });
+
+    it('should handle malformed JSON in request body', async () => {
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Content-Type', 'application/json')
+        .send('{"invalid": json}');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid JSON in request body'
+      });
+    });
+
+    it('should handle requests with missing content-type header', async () => {
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send('mood=happy');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Content-Type must be application/json'
+      });
+    });
+
+    it('should handle concurrent requests gracefully', async () => {
+      const validMoodData = { mood: MoodType.HAPPY, note: 'Test' };
+      const mockEntry = {
+        id: 'mood123',
+        userId: 'user123',
+        mood: MoodType.HAPPY,
+        note: 'Test',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      mockMoodService.createMoodEntry.mockResolvedValue(mockEntry);
+
+      const promises = Array.from({ length: 5 }, () =>
+        request(app)
+          .post('/api/mood')
+          .set('Authorization', 'Bearer valid-token')
+          .send(validMoodData)
+      );
+
+      const responses = await Promise.all(promises);
+      
+      responses.forEach(response => {
+        expect(response.status).toBe(201);
+        expect(response.body.success).toBe(true);
+      });
+    });
+
+    it('should handle extremely large request payloads', async () => {
+      const largeNote = 'a'.repeat(10000);
+      
+      const response = await request(app)
+        .post('/api/mood')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ mood: MoodType.HAPPY, note: largeNote });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Request payload too large'
+      });
+    });
+
+    it('should handle database connection timeouts', async () => {
+      mockMoodService.getMoodEntries.mockRejectedValue(new Error('Connection timeout'));
+
+      const response = await request(app)
+        .get('/api/mood')
+        .set('Authorization', 'Bearer valid-token');
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error'
+      });
+    });
+  });
+});

--- a/backend/routes/api/mood.ts
+++ b/backend/routes/api/mood.ts
@@ -1,10 +1,19 @@
-import { Router } from 'express';
-
-const router = Router();
-
+/**
+ * GET /api/mood
+ * Returns the current mood status with an encouraging message.
+ *
+ * @route GET /api/mood
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Object} 200 - Mood response object
+ * @returns {string} 200.mood - The current mood message
+ * @example
+ * // GET /api/mood
+ * // Response:
+ * // {
+ * //   "mood": "happy to be alive today. It is only for today"
+ * // }
+ */
 router.get('/', (req, res) => {
-    // Placeholder response
-    res.json({ mood: 'happy' });
+    res.json({ mood: 'happy to be alive today. It is only for today' });
 });
-
-export default router;

--- a/backend/routes/api/onboarding.test.ts
+++ b/backend/routes/api/onboarding.test.ts
@@ -1,0 +1,552 @@
+import request from 'supertest';
+import { app } from '../../app';
+import { prisma } from '../../lib/prisma';
+import { jest } from '@jest/globals';
+
+// Mock external dependencies
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    user: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    onboardingStep: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../lib/auth', () => ({
+  validateToken: jest.fn(),
+  generateToken: jest.fn(),
+}));
+
+jest.mock('../../lib/email', () => ({
+  sendWelcomeEmail: jest.fn(),
+}));
+
+describe('Onboarding API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('POST /api/onboarding/start', () => {
+    const validOnboardingData = {
+      email: 'test@example.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      company: 'Test Company',
+      role: 'Developer',
+    };
+
+    it('should successfully start onboarding with valid data', async () => {
+      const mockUser = {
+        id: 1,
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        onboardingCompleted: false,
+      };
+
+      (prisma.user.create as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.onboardingStep.create as jest.Mock).mockResolvedValue({
+        id: 1,
+        userId: 1,
+        step: 'profile',
+        completed: false,
+      });
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(validOnboardingData)
+        .expect(201);
+
+      expect(response.body).toEqual({
+        success: true,
+        user: mockUser,
+        message: 'Onboarding started successfully',
+      });
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: 'test@example.com',
+          firstName: 'John',
+          lastName: 'Doe',
+          company: 'Test Company',
+          role: 'Developer',
+          onboardingCompleted: false,
+        }),
+      });
+    });
+
+    it('should return 400 for missing required fields', async () => {
+      const invalidData = {
+        email: 'test@example.com',
+        // Missing firstName, lastName, company, role
+      };
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(invalidData)
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Missing required fields',
+        details: expect.any(Array),
+      });
+
+      expect(prisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for invalid email format', async () => {
+      const invalidEmailData = {
+        ...validOnboardingData,
+        email: 'invalid-email-format',
+      };
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(invalidEmailData)
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid email format',
+      });
+    });
+
+    it('should return 409 for duplicate email', async () => {
+      const duplicateError = new Error('Duplicate email');
+      (duplicateError as any).code = 'P2002';
+
+      (prisma.user.create as jest.Mock).mockRejectedValue(duplicateError);
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(validOnboardingData)
+        .expect(409);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'User with this email already exists',
+      });
+    });
+
+    it('should handle database errors gracefully', async () => {
+      (prisma.user.create as jest.Mock).mockRejectedValue(
+        new Error('Database connection failed')
+      );
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(validOnboardingData)
+        .expect(500);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error',
+      });
+    });
+
+    it('should handle empty request body', async () => {
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send({})
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Missing required fields',
+        details: expect.any(Array),
+      });
+    });
+
+    it('should trim whitespace from string fields', async () => {
+      const dataWithWhitespace = {
+        email: '  test@example.com  ',
+        firstName: '  John  ',
+        lastName: '  Doe  ',
+        company: '  Test Company  ',
+        role: '  Developer  ',
+      };
+
+      const mockUser = {
+        id: 1,
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        onboardingCompleted: false,
+      };
+
+      (prisma.user.create as jest.Mock).mockResolvedValue(mockUser);
+
+      await request(app)
+        .post('/api/onboarding/start')
+        .send(dataWithWhitespace)
+        .expect(201);
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: 'test@example.com',
+          firstName: 'John',
+          lastName: 'Doe',
+          company: 'Test Company',
+          role: 'Developer',
+        }),
+      });
+    });
+  });
+
+  describe('GET /api/onboarding/steps/:userId', () => {
+    it('should return onboarding steps for valid user', async () => {
+      const mockSteps = [
+        { id: 1, step: 'profile', completed: true, userId: 1 },
+        { id: 2, step: 'preferences', completed: false, userId: 1 },
+        { id: 3, step: 'verification', completed: false, userId: 1 },
+      ];
+
+      (prisma.onboardingStep.findMany as jest.Mock).mockResolvedValue(mockSteps);
+
+      const response = await request(app)
+        .get('/api/onboarding/steps/1')
+        .expect(200);
+
+      expect(response.body).toEqual({
+        success: true,
+        steps: mockSteps,
+        completedSteps: 1,
+        totalSteps: 3,
+      });
+    });
+
+    it('should return 404 for non-existent user', async () => {
+      (prisma.onboardingStep.findMany as jest.Mock).mockResolvedValue([]);
+
+      const response = await request(app)
+        .get('/api/onboarding/steps/999')
+        .expect(404);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'User not found or no onboarding steps',
+      });
+    });
+
+    it('should return 400 for invalid user ID', async () => {
+      const response = await request(app)
+        .get('/api/onboarding/steps/invalid')
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid user ID',
+      });
+    });
+
+    it('should handle database errors', async () => {
+      (prisma.onboardingStep.findMany as jest.Mock).mockRejectedValue(
+        new Error('Database error')
+      );
+
+      const response = await request(app)
+        .get('/api/onboarding/steps/1')
+        .expect(500);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error',
+      });
+    });
+  });
+
+  describe('PUT /api/onboarding/step/:stepId', () => {
+    const validStepUpdate = {
+      completed: true,
+      data: {
+        preferences: ['email', 'push'],
+      },
+    };
+
+    it('should successfully update onboarding step', async () => {
+      const mockUpdatedStep = {
+        id: 1,
+        step: 'preferences',
+        completed: true,
+        userId: 1,
+        data: { preferences: ['email', 'push'] },
+      };
+
+      (prisma.onboardingStep.update as jest.Mock).mockResolvedValue(mockUpdatedStep);
+
+      const response = await request(app)
+        .put('/api/onboarding/step/1')
+        .send(validStepUpdate)
+        .expect(200);
+
+      expect(response.body).toEqual({
+        success: true,
+        step: mockUpdatedStep,
+        message: 'Step updated successfully',
+      });
+
+      expect(prisma.onboardingStep.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: validStepUpdate,
+      });
+    });
+
+    it('should return 404 for non-existent step', async () => {
+      (prisma.onboardingStep.update as jest.Mock).mockRejectedValue(
+        new Error('Record not found')
+      );
+
+      const response = await request(app)
+        .put('/api/onboarding/step/999')
+        .send(validStepUpdate)
+        .expect(404);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Onboarding step not found',
+      });
+    });
+
+    it('should return 400 for invalid step ID', async () => {
+      const response = await request(app)
+        .put('/api/onboarding/step/invalid')
+        .send(validStepUpdate)
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid step ID',
+      });
+    });
+
+    it('should validate completed field type', async () => {
+      const invalidUpdate = {
+        completed: 'not a boolean',
+      };
+
+      const response = await request(app)
+        .put('/api/onboarding/step/1')
+        .send(invalidUpdate)
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid data types',
+      });
+    });
+  });
+
+  describe('POST /api/onboarding/complete/:userId', () => {
+    it('should successfully complete onboarding', async () => {
+      const mockUser = {
+        id: 1,
+        email: 'test@example.com',
+        onboardingCompleted: true,
+      };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUser);
+
+      const response = await request(app)
+        .post('/api/onboarding/complete/1')
+        .expect(200);
+
+      expect(response.body).toEqual({
+        success: true,
+        user: mockUser,
+        message: 'Onboarding completed successfully',
+      });
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { onboardingCompleted: true },
+      });
+    });
+
+    it('should return 404 for non-existent user', async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(
+        new Error('Record not found')
+      );
+
+      const response = await request(app)
+        .post('/api/onboarding/complete/999')
+        .expect(404);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'User not found',
+      });
+    });
+
+    it('should return 400 for invalid user ID', async () => {
+      const response = await request(app)
+        .post('/api/onboarding/complete/invalid')
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid user ID',
+      });
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    it('should handle malformed JSON in request body', async () => {
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send('invalid json')
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid JSON format',
+      });
+    });
+
+    it('should handle extremely long field values', async () => {
+      const longString = 'a'.repeat(1000);
+      const dataWithLongValues = {
+        email: 'test@example.com',
+        firstName: longString,
+        lastName: longString,
+        company: longString,
+        role: longString,
+      };
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(dataWithLongValues)
+        .expect(400);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Field values too long',
+      });
+    });
+
+    it('should handle SQL injection attempts', async () => {
+      const maliciousData = {
+        email: 'test@example.com',
+        firstName: "'; DROP TABLE users; --",
+        lastName: 'Doe',
+        company: 'Test Company',
+        role: 'Developer',
+      };
+
+      (prisma.user.create as jest.Mock).mockResolvedValue({
+        id: 1,
+        email: 'test@example.com',
+        firstName: "'; DROP TABLE users; --",
+        lastName: 'Doe',
+        onboardingCompleted: false,
+      });
+
+      const response = await request(app)
+        .post('/api/onboarding/start')
+        .send(maliciousData)
+        .expect(201);
+
+      // Should still succeed but with sanitized data
+      expect(response.body.success).toBe(true);
+      expect(prisma.user.create).toHaveBeenCalled();
+    });
+
+    it('should handle concurrent requests gracefully', async () => {
+      const mockUser = {
+        id: 1,
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        onboardingCompleted: false,
+      };
+
+      (prisma.user.create as jest.Mock).mockResolvedValue(mockUser);
+
+      const requests = Array(10).fill(null).map(() =>
+        request(app)
+          .post('/api/onboarding/start')
+          .send(validOnboardingData)
+      );
+
+      const responses = await Promise.all(requests);
+
+      // First request should succeed, others should fail with duplicate email
+      const successfulResponses = responses.filter(r => r.status === 201);
+      const failedResponses = responses.filter(r => r.status === 409);
+
+      expect(successfulResponses.length).toBeGreaterThan(0);
+      expect(failedResponses.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Authentication and Authorization', () => {
+    it('should require authentication for protected endpoints', async () => {
+      const response = await request(app)
+        .get('/api/onboarding/steps/1')
+        .expect(401);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Authentication required',
+      });
+    });
+
+    it('should validate user permissions for user-specific operations', async () => {
+      const response = await request(app)
+        .get('/api/onboarding/steps/1')
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(403);
+
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Insufficient permissions',
+      });
+    });
+  });
+
+  describe('Performance and Scalability', () => {
+    it('should handle large datasets efficiently', async () => {
+      const largeStepsArray = Array(100).fill(null).map((_, index) => ({
+        id: index + 1,
+        step: `step_${index}`,
+        completed: index % 2 === 0,
+        userId: 1,
+      }));
+
+      (prisma.onboardingStep.findMany as jest.Mock).mockResolvedValue(largeStepsArray);
+
+      const response = await request(app)
+        .get('/api/onboarding/steps/1')
+        .expect(200);
+
+      expect(response.body.steps).toHaveLength(100);
+      expect(response.body.completedSteps).toBe(50);
+    });
+
+    it('should implement proper pagination for large results', async () => {
+      const response = await request(app)
+        .get('/api/onboarding/steps/1?page=2&limit=10')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('pagination');
+      expect(response.body.pagination).toEqual({
+        page: 2,
+        limit: 10,
+        total: expect.any(Number),
+        hasNext: expect.any(Boolean),
+        hasPrev: expect.any(Boolean),
+      });
+    });
+  });
+});

--- a/backend/routes/api/onboarding.ts
+++ b/backend/routes/api/onboarding.ts
@@ -1,10 +1,21 @@
-import { Router } from 'express';
-
-const router = Router();
-
+/**
+ * POST /api/onboarding
+ * Completes the user onboarding process and returns a personalized success message.
+ *
+ * @route POST /api/onboarding
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @returns {Object} 200 - Onboarding completion response
+ * @returns {string} 200.message - Personalized completion message
+ * @returns {boolean} 200.successful_onboarding - Flag indicating successful onboarding
+ * @example
+ * // POST /api/onboarding
+ * // Response:
+ * // {
+ * //   "message": "You're personalization is complete.",
+ * //   "successful_onboarding": true
+ * // }
+ */
 router.post('/', (req, res) => {
-    // Placeholder onboarding logic
-    res.json({ message: 'Onboarding complete' });
+    res.json({ message: "You're personalization is complete.", successful_onboarding: true });
 });
-
-export default router;


### PR DESCRIPTION
## Summary by Sourcery

Add JSDoc documentation for onboarding and mood API routes and refine their JSON responses.

Enhancements:
- Add JSDoc comments with request/response schemas for POST /api/onboarding and GET /api/mood endpoints.
- Update onboarding endpoint to include a personalized message and a successful_onboarding boolean flag.
- Enhance mood endpoint to return a more expressive and encouraging message.