### PR TITLE
Add theme selection dropdown, restructure counter, update Tailwind config

### DIFF
--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -4,3 +4,4 @@ export default {
     autoprefixer: {},
   },
 };
+

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,16 +7,66 @@ function App() {
   return (
     <>
       <h1>Sunrise</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
+      <div className="dropdown mb-72">
+  <div tabIndex={0} role="button" className="btn m-1">
+    Theme
+    <svg
+      width="12px"
+      height="12px"
+      className="inline-block h-2 w-2 fill-current opacity-60"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 2048 2048">
+      <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path>
+    </svg>
+  </div>
+  <ul tabIndex={0} className="dropdown-content bg-base-300 rounded-box z-1 w-52 p-2 shadow-2xl">
+    <li>
+      <input
+        type="radio"
+        name="theme-dropdown"
+        className="theme-controller w-full btn btn-sm btn-block btn-ghost justify-start"
+        aria-label="Default"
+        value="default" />
+    </li>
+    <li>
+      <input
+        type="radio"
+        name="theme-dropdown"
+        className="theme-controller w-full btn btn-sm btn-block btn-ghost justify-start"
+        aria-label="Retro"
+        value="retro" />
+    </li>
+    <li>
+      <input
+        type="radio"
+        name="theme-dropdown"
+        className="theme-controller w-full btn btn-sm btn-block btn-ghost justify-start"
+        aria-label="Cyberpunk"
+        value="cyberpunk" />
+    </li>
+    <li>
+      <input
+        type="radio"
+        name="theme-dropdown"
+        className="theme-controller w-full btn btn-sm btn-block btn-ghost justify-start"
+        aria-label="Valentine"
+        value="valentine" />
+    </li>
+    <li>
+      <input
+        type="radio"
+        name="theme-dropdown"
+        className="theme-controller w-full btn btn-sm btn-block btn-ghost justify-start"
+        aria-label="Aqua"
+        value="aqua" />
+    </li>
+  </ul>
+</div>
       <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
+        Time to get started with <code>Sunrise</code>!<br />
+        <button className="btn btn-accent btn-lg" onClick={() => setCount((count) => count + 1)}>
+          Count is: {count}
+        </button>
       </p>
     </>
   )

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react'
 import './App.scss'
 
+/**
+ * Renders the main application UI with a theme selection dropdown and a counter button.
+ *
+ * Displays a heading, a dropdown menu for selecting between multiple visual themes, a welcome message, and a button that increments and displays a count when clicked.
+ *
+ * @returns The rendered React component for the Sunrise application.
+ */
 function App() {
   const [count, setCount] = useState(0)
 

--- a/app/src/index.scss
+++ b/app/src/index.scss
@@ -70,3 +70,7 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+// Daisy UI External Theme
+// The @plugin "daisyui/theme" block was removed because @plugin is not valid SCSS.
+// If you want to customize DaisyUI themes, do so in your tailwind.config.js instead.

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -8,4 +8,59 @@ module.exports = {
     extend: {},
   },
   plugins: [require("daisyui")],
+  daisyui: {
+    themes: [
+      {
+        mytheme: {
+          "primary": "#570df8",
+          "secondary": "#f000b8",
+          "accent": "#37cdbe",
+          "neutral": "#3d4451",
+          "base-100": "#ffffff",
+          "info": "#3abff8",
+          "success": "#36d399",
+          "warning": "#fbbd23",
+          "error": "#f87272",
+        },
+        sunrise: {
+          "primary": "oklch(62% 0.214 259.815)",
+          "primary-content": "oklch(97% 0.014 254.604)",
+          "secondary": "oklch(62% 0.214 259.815)",
+          "secondary-content": "oklch(97% 0.014 254.604)",
+          "accent": "oklch(70% 0.14 182.503)",
+          "accent-content": "oklch(98% 0.014 180.72)",
+          "neutral": "oklch(14% 0.005 285.823)",
+          "neutral-content": "oklch(98% 0 0)",
+          "base-100": "oklch(98% 0 0)",
+          "base-200": "oklch(96% 0.001 286.375)",
+          "base-300": "oklch(92% 0.004 286.32)",
+          "base-content": "oklch(21% 0.006 285.885)",
+          "info": "oklch(62% 0.214 259.815)",
+          "info-content": "oklch(97% 0.014 254.604)",
+          "success": "oklch(72% 0.219 149.579)",
+          "success-content": "oklch(98% 0.018 155.826)",
+          "warning": "oklch(79% 0.184 86.047)",
+          "warning-content": "oklch(98% 0.026 102.212)",
+          "error": "oklch(65% 0.241 354.308)",
+          "error-content": "oklch(97% 0.014 343.198)",
+          "--radius-selector": "0.25rem",
+          "--radius-field": "1rem",
+          "--radius-box": "0.5rem",
+          "--size-selector": "0.25rem",
+          "--size-field": "0.25rem",
+          "--border": "1px",
+          "--depth": "0",
+          "--noise": "1",
+        },
+      },
+      "light", // you can add more built-in or custom themes
+    ],
+    darkTheme: false, // disables dark mode
+    base: true, // enables base styles
+    styled: true, // enables daisyUI styled components
+    utils: true, // enables daisyUI utility classes
+    logs: true, // disables daisyUI logs
+    lightTheme: "sunrise", // set mytheme as the light them
+    defaultTheme: "sunrise", // set sunrise as the default theme
+  },
 };


### PR DESCRIPTION
## Summary by Sourcery

Introduce a theme selector UI in the main App and configure DaisyUI with custom themes.

New Features:
- Add a dropdown theme controller in the App with radio options for Default, Retro, Cyberpunk, Valentine, and Aqua.

Enhancements:
- Replace the default Vite counter card with a styled theme selector and update the count button.
- Extend Tailwind CSS configuration with DaisyUI custom themes (mytheme, sunrise) and set sunrise as the default light theme, disabling dark mode.

Documentation:
- Remove the invalid @plugin block from index.scss and direct theme customization to tailwind.config.js.

Chores:
- Add a trailing newline in postcss.config.js for proper formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a theme selection dropdown allowing users to switch between multiple themes, including new custom themes.
  * Added comprehensive theming options with enhanced color palettes and styling for a more customizable UI experience.

* **UI Updates**
  * Redesigned the main interface with an updated welcome message and improved button placement and styling for incrementing the counter.

* **Documentation**
  * Clarified SCSS usage with comments regarding theme customization and removed invalid syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->